### PR TITLE
Add configuration of certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY ./run.sh /run.sh
 
 RUN chmod +x /run.sh
 
-CMD ["/run.sh"]
+ENTRYPOINT ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ if [ -z ${renew+x} ]; then
 
   if [ -z ${distinct+x} ]; then
 
-    certbot certonly --verbose --noninteractive --quiet --standalone --agree-tos --email="${email}" -d "${domains}"; else
+    certbot certonly --verbose --noninteractive --quiet --standalone --agree-tos --email="${email}" -d "${domains}" $@; else
 
     IFS=',' read -ra ADDR <<< "$domains"
     for domain in "${ADDR[@]}"; do

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ if [ -z ${renew+x} ]; then
 
     IFS=',' read -ra ADDR <<< "$domains"
     for domain in "${ADDR[@]}"; do
-        certbot certonly --verbose --noninteractive --quiet --standalone --agree-tos --email="${email}" -d "${domain}"
+        certbot certonly --verbose --noninteractive --quiet --standalone --agree-tos --email="${email}" -d "${domain}" $@;
     done
 
   fi; else


### PR DESCRIPTION
you can append certbot arguments after the docker run command now:
`docker run -v /vault/ssl:/etc/letsencrypt -e domains="example.com" -e email="info@example.com" -p 80:80 -p 443:443 --rm pierreprinetti/certbot:latest --rsa-key-size 4096`